### PR TITLE
fix typo in example notebook

### DIFF
--- a/examples/lasso_admm.ipynb
+++ b/examples/lasso_admm.ipynb
@@ -10,7 +10,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -25,7 +27,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def show_plot(coef, value, coef_expected = None, value_expected = None, suptitle=None):\n",
@@ -67,7 +71,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# fix the seed of random\n",
@@ -77,7 +83,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Generate signal\n",
@@ -89,7 +97,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Generate observation matrix(random) and observation result\n",
@@ -131,7 +141,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# constants\n",
@@ -141,7 +153,9 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import sys\n",
@@ -154,7 +168,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def get_signal(model, X, y):\n",
@@ -166,7 +182,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## LASSO coodinate descent (sklearn implementation)"
+    "## LASSO coordinate descent (sklearn implementation)"
    ]
   },
   {
@@ -330,9 +346,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "spm-image Examples",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "spm-image-examples"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -344,7 +360,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I fixed typo.
`coodinate descent` -> `coordinate descent`