### PR TITLE
Preallocate `n_iter_` array

### DIFF
--- a/spmimage/linear_model/admm.py
+++ b/spmimage/linear_model/admm.py
@@ -81,7 +81,7 @@ def _admm(X: np.ndarray, y: np.ndarray, D: np.ndarray, alpha: float, rho: float,
     inv_matrix_DT = inv_matrix.dot(rho * D.T)
     threshold = alpha / rho
 
-    n_iter_ = []
+    n_iter_ = np.empty((n_targets,), dtype=int)
     # Update ADMM parameters by columns
     for k in range(n_targets):
         # initial cost
@@ -100,8 +100,8 @@ def _admm(X: np.ndarray, y: np.ndarray, D: np.ndarray, alpha: float, rho: float,
             gap = np.abs(cost - pre_cost)
             if gap < tol:
                 break
-        n_iter_.append(t)
-    return np.squeeze(w_t), n_iter_
+        n_iter_[k] = t
+    return np.squeeze(w_t), n_iter_.tolist()
 
 
 class GeneralizedLasso(LinearModel, RegressorMixin):


### PR DESCRIPTION
Before starting the `n_targets` `for`-loop, preallocate an array for `n_iter_` to store each iteration length into as we know how many values we need and of what type. This is a pretty mild improvement by itself, but it should make it a bit easier to Cythonize the code and parallelize this loop.

xref: https://github.com/hacarus/spm-image/issues/35
xref: https://github.com/hacarus/spm-image/issues/41