### PR TITLE
update .travis.yml to run test in 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
+dist: xenial
 language: python
 python:
   - '3.5'
   - '3.6'
+  - '3.7'
 install: travis_wait pip install -r requirements.txt
 script: travis_wait 30 python -m unittest discover
 notifications:


### PR DESCRIPTION
The test has succeeded in the following build

* https://travis-ci.org/hacarus/spm-image/builds/511216312

# Summary

* Add Python 3.7 setting in `.travis.yml`
* For more details, refer to #50