### PR TITLE
Issue/66/normalize dictionaries in unittest

### DIFF
--- a/tests/test_decomposition_dict_learning.py
+++ b/tests/test_decomposition_dict_learning.py
@@ -43,7 +43,7 @@ class TestDictLearning(unittest.TestCase):
 
         # check error of learning
         # print(np.linalg.norm(mask*(X-W.dot(A0)), 'fro'))
-        self.assertTrue(np.linalg.norm(mask * (X - W.dot(A0)), 'fro') < 50)
+        self.assertTrue(np.linalg.norm(mask * (X - W.dot(A0)), 'fro') < np.linalg.norm(mask * X, 'fro'))
 
     def test_sparse_encode(self):
         k0 = 3
@@ -52,7 +52,6 @@ class TestDictLearning(unittest.TestCase):
         n_components = 10
 
         A0, X = generate_dictionary_and_samples(n_samples, n_features, n_components, k0)
-        A0 = normalize(A0)
 
         W1 = sparse_encode(X, A0, algorithm='omp', n_nonzero_coefs=k0)
         W2 = spmimage.decomposition.sparse_encode(X, A0, algorithm='omp', n_nonzero_coefs=k0)
@@ -67,7 +66,6 @@ class TestDictLearning(unittest.TestCase):
         n_components = 10
 
         A0, X = generate_dictionary_and_samples(n_samples, n_features, n_components, k0)
-        A0 = normalize(A0)
 
         W = spmimage.decomposition.sparse_encode(X, A0, algorithm='mp', n_nonzero_coefs=k0)
 
@@ -82,7 +80,6 @@ class TestDictLearning(unittest.TestCase):
         n_components = 10
 
         A0, X = generate_dictionary_and_samples(n_samples, n_features, n_components, k0)
-        A0 = normalize(A0)
 
         W = spmimage.decomposition.sparse_encode(X, A0, algorithm='mp', n_nonzero_coefs=k0, n_jobs=2)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 from typing import Tuple
 
 import numpy as np
+from sklearn.preprocessing import normalize
 
 
 def generate_dictionary_and_samples(n_samples: int, n_features: int, n_components: int, n_nonzero_coefs: int) \
@@ -14,4 +15,5 @@ def generate_dictionary_and_samples(n_samples: int, n_features: int, n_component
         # select n_nonzero_coefs components from dictionary
         X[i, :] = np.dot(np.random.randn(n_nonzero_coefs),
                          A0[np.random.permutation(range(n_components))[:n_nonzero_coefs], :])
-    return A0, X
+    A0 = normalize(A0)
+    return A0, X # A0 is normalized


### PR DESCRIPTION
# Summary

* Normalized dictionaries in unittest. (They have to be normalized when they are an input of OMP algorithm!)

# Related Issues/Wiki/Resources

* #66 
