### PR TITLE
Hotfix: require scikit-learn>=0.24.0  (closes #92)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 scipy
 scikit-learn>=0.19.0
+joblib

--- a/spmimage/decomposition/ksvd.py
+++ b/spmimage/decomposition/ksvd.py
@@ -3,7 +3,7 @@ from logging import getLogger
 import numpy as np
 
 from sklearn.base import BaseEstimator
-from sklearn.decomposition.dict_learning import SparseCodingMixin, sparse_encode
+from sklearn.decomposition._dict_learning import _BaseSparseCoding, sparse_encode
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
 from .dict_learning import sparse_encode_with_mask
@@ -98,7 +98,7 @@ def _ksvd(Y: np.ndarray, n_components: int, n_nonzero_coefs: int, max_iter: int,
     return W, H, errors, k + 1
 
 
-class KSVD(BaseEstimator, SparseCodingMixin):
+class KSVD(BaseEstimator, _BaseSparseCoding):
     """ K-SVD
     Finds a dictionary that can be used to represent data using a sparse code.
     Solves the optimization problem:

--- a/spmimage/linear_model/admm.py
+++ b/spmimage/linear_model/admm.py
@@ -9,7 +9,7 @@ from sklearn.utils import check_array, check_X_y
 from sklearn.base import RegressorMixin
 from sklearn.linear_model.base import LinearModel
 from sklearn.linear_model.coordinate_descent import _alpha_grid
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 
 logger = getLogger(__name__)
 

--- a/spmimage/linear_model/admm.py
+++ b/spmimage/linear_model/admm.py
@@ -7,8 +7,8 @@ import scipy as sp
 
 from sklearn.utils import check_array, check_X_y
 from sklearn.base import RegressorMixin
-from sklearn.linear_model.base import LinearModel
-from sklearn.linear_model.coordinate_descent import _alpha_grid
+from sklearn.linear_model._base import LinearModel
+from sklearn.linear_model._coordinate_descent import _alpha_grid
 from joblib import Parallel, delayed
 
 logger = getLogger(__name__)


### PR DESCRIPTION
# Summary
- Use joblib.joblib instead of removed sklearn... since 0.23.0
- Reflect API change in sklearn.dict_learning and sklearn.linear_model to support sklearn >= 0.24.0
- require sklearn >= 0.24.0
# Related Issues/Wiki/Resources
- #93 and #92
