### PR TITLE
Support sklearn>=0.24.0, and drop older ones (closes #92)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 dist: xenial
 language: python
 python:
-  - '3.5'
-  - '3.6'
   - '3.7'
+  - '3.8'
+  - '3.9'
 install: travis_wait pip install -r requirements.txt
 script: travis_wait 30 python -m unittest discover
 notifications:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 scipy
-scikit-learn>=0.19.0
+scikit-learn>=0.24.0
+joblib

--- a/spmimage/decomposition/ksvd.py
+++ b/spmimage/decomposition/ksvd.py
@@ -204,9 +204,12 @@ class KSVD(BaseEstimator, _BaseSparseCoding):
                  transform_n_nonzero_coefs=None,
                  transform_alpha=None, n_jobs=1,
                  split_sign=False, random_state=None, method='approximate', dict_init=None):
-        self.__init__(n_components, transform_algorithm,
-                                       transform_n_nonzero_coefs,
-                                       transform_alpha, split_sign, n_jobs)
+        self.n_components = n_components
+        self.transform_algorithm = transform_algorithm
+        self.transform_n_nonzero_coefs = transform_n_nonzero_coefs
+        self.transform_alpha = transform_alpha
+        self.split_sign = split_sign
+        self.n_jobs = n_jobs
         self.max_iter = max_iter
         self.tol = tol
         self.missing_value = missing_value

--- a/spmimage/decomposition/ksvd.py
+++ b/spmimage/decomposition/ksvd.py
@@ -203,8 +203,10 @@ class KSVD(BaseEstimator, _BaseSparseCoding):
                  missing_value=None, transform_algorithm='omp',
                  transform_n_nonzero_coefs=None,
                  transform_max_iter=None,
+                 positive_code=False,
                  transform_alpha=None, n_jobs=1,
                  split_sign=False, random_state=None, method='approximate', dict_init=None):
+                 
         self.n_components = n_components
         self.transform_algorithm = transform_algorithm
         self.transform_n_nonzero_coefs = transform_n_nonzero_coefs
@@ -214,6 +216,7 @@ class KSVD(BaseEstimator, _BaseSparseCoding):
         self.n_jobs = n_jobs
         self.max_iter = max_iter
         self.tol = tol
+        self.positive_code = positive_code
         self.missing_value = missing_value
         self.random_state = random_state
         self.method = method

--- a/spmimage/decomposition/ksvd.py
+++ b/spmimage/decomposition/ksvd.py
@@ -2,7 +2,7 @@ from logging import getLogger
 
 import numpy as np
 from sklearn.base import BaseEstimator
-from sklearn.decomposition.dict_learning import SparseCodingMixin, sparse_encode
+from sklearn.decomposition._dict_learning import _BaseSparseCoding, sparse_encode
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
 
@@ -116,7 +116,7 @@ def _ksvd(Y: np.ndarray, n_components: int, n_nonzero_coefs: int, max_iter: int,
     return W, H, errors, k + 1
 
 
-class KSVD(BaseEstimator, SparseCodingMixin):
+class KSVD(BaseEstimator, _BaseSparseCoding):
     """ K-SVD
     Finds a dictionary that can be used to represent data using a sparse code.
     Solves the optimization problem:

--- a/spmimage/decomposition/ksvd.py
+++ b/spmimage/decomposition/ksvd.py
@@ -207,6 +207,7 @@ class KSVD(BaseEstimator, _BaseSparseCoding):
         self.n_components = n_components
         self.transform_algorithm = transform_algorithm
         self.transform_n_nonzero_coefs = transform_n_nonzero_coefs
+        self.transform_max_iter = transform_max_iter
         self.transform_alpha = transform_alpha
         self.split_sign = split_sign
         self.n_jobs = n_jobs

--- a/spmimage/decomposition/ksvd.py
+++ b/spmimage/decomposition/ksvd.py
@@ -204,7 +204,7 @@ class KSVD(BaseEstimator, _BaseSparseCoding):
                  transform_n_nonzero_coefs=None,
                  transform_alpha=None, n_jobs=1,
                  split_sign=False, random_state=None, method='approximate', dict_init=None):
-        self._set_sparse_coding_params(n_components, transform_algorithm,
+        self.__init__(n_components, transform_algorithm,
                                        transform_n_nonzero_coefs,
                                        transform_alpha, split_sign, n_jobs)
         self.max_iter = max_iter

--- a/spmimage/decomposition/ksvd.py
+++ b/spmimage/decomposition/ksvd.py
@@ -202,6 +202,7 @@ class KSVD(BaseEstimator, _BaseSparseCoding):
     def __init__(self, n_components=None, max_iter=1000, tol=1e-8,
                  missing_value=None, transform_algorithm='omp',
                  transform_n_nonzero_coefs=None,
+                 transform_max_iter=None,
                  transform_alpha=None, n_jobs=1,
                  split_sign=False, random_state=None, method='approximate', dict_init=None):
         self.n_components = n_components

--- a/spmimage/linear_model/_ppd.py
+++ b/spmimage/linear_model/_ppd.py
@@ -3,7 +3,7 @@ from logging import getLogger
 from abc import abstractmethod, ABC
 
 from sklearn.base import RegressorMixin
-from sklearn.linear_model.base import LinearModel
+from sklearn.linear_model._base import LinearModel
 
 from typing import Tuple
 import numpy as np

--- a/spmimage/linear_model/admm.py
+++ b/spmimage/linear_model/admm.py
@@ -5,8 +5,8 @@ import numpy as np
 
 from sklearn.utils import check_array, check_X_y
 from sklearn.base import RegressorMixin
-from sklearn.linear_model.base import LinearModel
-from sklearn.linear_model.coordinate_descent import _alpha_grid
+from sklearn.linear_model._base import LinearModel
+from sklearn.linear_model._coordinate_descent import _alpha_grid
 from joblib import Parallel, delayed
 
 logger = getLogger(__name__)


### PR DESCRIPTION
# Summary
- Use joblib.joblib instead of removed sklearn... since 0.23.0
- Reflect API change in sklearn.dict_learning and sklearn.linear_model to support sklearn >= 0.24.0
- require sklearn >= 0.24.0
# Related Issues/Wiki/Resources
- #93 and #92
